### PR TITLE
Add explicit dependency on jetty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,7 @@ dependencies {
 
   implementation ("org.jolokia:jolokia-core:$jolokiaVersion")
   implementation ("org.jolokia:jolokia-jsr160:$jolokiaVersion")
+  implementation ("org.eclipse.jetty.aggregate:jetty-all:9.4.44.v20210927")
 
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion")
   umlDoclet("nl.talsmasoftware:umldoclet:1.1.4")

--- a/src/main/java/com/adaptris/core/management/jolokia/FromProperties.java
+++ b/src/main/java/com/adaptris/core/management/jolokia/FromProperties.java
@@ -16,11 +16,13 @@
 package com.adaptris.core.management.jolokia;
 
 import java.util.Properties;
-
+import javax.servlet.ServletContext;
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.security.Authenticator;
+import org.eclipse.jetty.security.Authenticator.AuthConfiguration;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
@@ -89,6 +91,18 @@ final class FromProperties extends ServerBuilder {
 
       ConstraintMapping constraintMapping = constraint();
       securityHandler.addConstraintMapping(constraintMapping);
+    } else {
+      // https://github.com/adaptris/interlok/pull/788
+      securityHandler.setAuthenticatorFactory(new Authenticator.Factory() {
+
+        @Override
+        public Authenticator getAuthenticator(Server server, ServletContext context,
+            AuthConfiguration configuration, IdentityService identityService,
+            LoginService loginService) {
+          return null;
+        }
+        
+      });
     }
 
     securityHandler.setHandler(handler);


### PR DESCRIPTION
## Motivation

This relates to https://github.com/adaptris/interlok/pull/788. The upgrade to 9.4.4 brings additional authenticator factories into play. Not everything that is required by JASPI is included in the dependency chain

## Modification

Add a default Authenticator.Factory that effectively disables authentication, if no security is required.
Add an explicit dependency on jetty rather than inheriting it from interlok-core/interlok-common

## PR Checklist

- [x] been self-reviewed.

## Result

It now works with jetty-9.4.4

## Testing

- Create a project that includes  `interlokRuntime ("org.eclipse.jetty.aggregate:jetty-all:9.4.44.v20210927")` using the existing interlok-jolokia SNAPSHOT build.
- Your bootstrap properties contains (i.e. jolokia is enabled, but no username + password).
```
managementComponents=jmx:jetty:jolokia
```
- Attempt to start it up, you will see an exception from `JaspiAuthenticatorFactory`
- Reconfigure bootstrap.properties so you have a username and password.
```
managementComponents=jmx:jetty:jolokia
jolokiaUsername=admin
jolokiaPassword=admin
```
- Restart; and it works.
- Switch to this PR build, and remove the username + password
- Restart, it should now work.


