### PR TITLE
Switch to using JettyServerManager directly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,11 +138,6 @@ dependencies {
   testImplementation ("org.mockito:mockito-inline:$mockitoVersion")
 
   testImplementation ("org.awaitility:awaitility:4.1.0")
-  // INTERLOK-3233 we still need log4j since we're doing MDC stuffs.
-  testImplementation ("org.apache.logging.log4j:log4j-core:$log4j2Version")
-  testImplementation ("org.apache.logging.log4j:log4j-api:$log4j2Version")
-  testImplementation ("org.apache.logging.log4j:log4j-1.2-api:$log4j2Version")
-  testImplementation ("org.apache.logging.log4j:log4j-slf4j-impl:$log4j2Version")
 
   javadoc("com.adaptris:interlok-core-apt:$interlokCoreVersion")
   offlineJavadocPackages ("com.adaptris:interlok-core:$interlokCoreVersion:javadoc@jar")

--- a/src/main/java/com/adaptris/core/management/jolokia/FromProperties.java
+++ b/src/main/java/com/adaptris/core/management/jolokia/FromProperties.java
@@ -48,10 +48,12 @@ final class FromProperties extends ServerBuilder {
 
   private final static String JOLOKIA_SERVLET_PATH = "/*";
   private final static String DEFAULT_JOLOKIA_CONTEXT_PATH = "/jolokia";
-
+  public static final String JOLOKIA_PORT_CFG_KEY = "jolokiaPort";
   public final static String JOLOKIA_CONTEXT_PATH_CFG_KEY = "jolokiaContextPath";
   public final static String JOLOKIA_USERNAME_CFG_KEY = "jolokiaUsername";
   public final static String JOLOKIA_PASSWORD_CFG_KEY = "jolokiaPassword";
+
+
 
   public FromProperties(Properties initialConfig) {
     super(initialConfig);

--- a/src/main/java/com/adaptris/core/management/jolokia/JettyServerWrapperImpl.java
+++ b/src/main/java/com/adaptris/core/management/jolokia/JettyServerWrapperImpl.java
@@ -1,16 +1,15 @@
 package com.adaptris.core.management.jolokia;
 
+import com.adaptris.core.management.webserver.JettyServerManager;
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adaptris.core.management.jetty.JettyServerComponent;
-import com.adaptris.core.management.webserver.JettyServerManager;
-import com.adaptris.core.management.webserver.WebServerManagementUtil;
-
 class JettyServerWrapperImpl implements JettyServerWrapper {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
+  private static final String FRIENDLY_NAME = JolokiaComponent.class.getSimpleName();
+  protected static final String SERVER_ID = JolokiaComponent.class.getSimpleName();
 
   private Server server;
 
@@ -20,8 +19,7 @@ class JettyServerWrapperImpl implements JettyServerWrapper {
 
   @Override
   public void register() {
-    final JettyServerManager jettyManager = (JettyServerManager) WebServerManagementUtil.getServerManager();
-    jettyManager.addServer(server);
+    JettyServerManager.getInstance().addServer(SERVER_ID, server);
   }
 
   @Override
@@ -29,10 +27,10 @@ class JettyServerWrapperImpl implements JettyServerWrapper {
     try {
       if (server.isStopped()) {
         server.start();
-        log.debug("{} Started", JettyServerComponent.class.getSimpleName());
+        log.debug("{} Started", FRIENDLY_NAME);
       }
     } catch (final Exception ex) {
-      log.error("Exception while starting Jetty", ex);
+      log.error("Exception while starting Jolokia(Jetty)", ex);
     }
   }
 
@@ -41,9 +39,9 @@ class JettyServerWrapperImpl implements JettyServerWrapper {
     try {
       server.stop();
       server.join();
-      log.debug("{} Stopped", JettyServerComponent.class.getSimpleName());
+      log.debug("{} Stopped", FRIENDLY_NAME);
     } catch (final Exception ex) {
-      log.error("Exception while stopping Jetty", ex);
+      log.error("Exception while stopping Jolokia(Jetty)", ex);
     }
 
   }
@@ -51,13 +49,11 @@ class JettyServerWrapperImpl implements JettyServerWrapper {
   @Override
   public void destroy() {
     try {
-      final JettyServerManager jettyManager = (JettyServerManager) WebServerManagementUtil.getServerManager();
-      jettyManager.removeServer(server);
+      JettyServerManager.getInstance().removeServer(SERVER_ID);
       server.destroy();
-      log.debug("{} Destroyed", JettyServerComponent.class.getSimpleName());
+      log.debug("{} Destroyed", FRIENDLY_NAME);
     } catch (final Exception ex) {
-      log.error("Exception while destroying Jetty", ex);
+      log.error("Exception while destroying Jolokia(Jetty)", ex);
     }
   }
-
 }

--- a/src/main/java/com/adaptris/core/management/jolokia/JolokiaComponent.java
+++ b/src/main/java/com/adaptris/core/management/jolokia/JolokiaComponent.java
@@ -38,18 +38,12 @@ public class JolokiaComponent extends MgmtComponentImpl {
 
   private static final long STARTUP_WAIT = TimeUnit.SECONDS.toMillis(60L);
 
-  private ClassLoader classLoader;
   private Properties properties;
 
   private JettyServerWrapper wrapper = new JettyServerWrapper() {
   };
 
   public JolokiaComponent() {
-  }
-
-  @Override
-  public void setClassLoader(final ClassLoader classLoader) {
-    this.classLoader = classLoader;
   }
 
   @Override
@@ -62,9 +56,7 @@ public class JolokiaComponent extends MgmtComponentImpl {
    */
   @Override
   public void start() throws Exception {
-    if (classLoader == null) {
-      classLoader = Thread.currentThread().getContextClassLoader();
-    }
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
     final CyclicBarrier barrier = new CyclicBarrier(2);
     // This is to make sure we don't break the barrier before the real delay is up.
     //

--- a/src/main/java/com/adaptris/core/management/jolokia/ServerBuilder.java
+++ b/src/main/java/com/adaptris/core/management/jolokia/ServerBuilder.java
@@ -12,25 +12,16 @@
  */
 package com.adaptris.core.management.jolokia;
 
-import static com.adaptris.core.management.jetty.JettyServerComponent.ATTR_BOOTSTRAP_KEYS;
-import static com.adaptris.core.management.jetty.JettyServerComponent.ATTR_JMX_ADAPTER_UID;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adaptris.core.management.Constants;
-
 public abstract class ServerBuilder {
-  public static final String JOLOKIA_PORT_CFG_KEY = "jolokiaPort";
-  public static final String WEB_SERVER_PORT_CFG_KEY = "webServerPort";
-  public static final String WEB_SERVER_CONFIG_FILE_NAME_CGF_KEY = "webServerConfigUrl";
-  public static final String WEB_SERVER_WEBAPP_URL_CFG_KEY = "webServerWebappUrl";
+
 
   private enum Builder {
     /*XML() {
@@ -86,25 +77,7 @@ public abstract class ServerBuilder {
   protected abstract Server build() throws Exception;
 
   protected static final Server build(final Properties config) throws Exception {
-    return configure(FACTORIES.stream().filter((b) -> b.canBuild(config)).findFirst().get().builder(config).build(), config);
-  }
-
-  // TODO We may not need that for jolokia?
-  private static Server configure(final Server server, final Properties config) throws Exception {
-    // TODO This is all wrong. Can't get server attributes from the ServletContext
-    // OLD-SKOOL Do it via SystemProperties!!!!!
-    // Add Null Prodction in to avoid System.setProperty issues during tests.
-    // Or in fact if people decide to not enable JMXServiceUrl in bootstrap.properties
-    if (config.containsKey(Constants.CFG_JMX_LOCAL_ADAPTER_UID)) {
-      // server.setAttribute(ATTR_JMX_ADAPTER_UID, config.getProperty(Constants.CFG_JMX_LOCAL_ADAPTER_UID));
-      System.setProperty(ATTR_JMX_ADAPTER_UID, config.getProperty(Constants.CFG_JMX_LOCAL_ADAPTER_UID));
-    }
-    if (config.containsKey(Constants.BOOTSTRAP_PROPERTIES_RESOURCE_KEY)) {
-      for (String s : ATTR_BOOTSTRAP_KEYS) {
-        System.setProperty(s, config.getProperty(Constants.BOOTSTRAP_PROPERTIES_RESOURCE_KEY));
-      }
-    }
-    return server;
+    return FACTORIES.stream().filter((b) -> b.canBuild(config)).findFirst().get().builder(config).build();
   }
 
   protected Properties getConfig() {
@@ -112,7 +85,7 @@ public abstract class ServerBuilder {
   }
 
   protected boolean containsConfigItem(String key) {
-    return initialProperties.containsKey(key);
+    return getConfig().containsKey(key);
   }
 
   protected String getConfigItem(String key) {
@@ -120,6 +93,6 @@ public abstract class ServerBuilder {
   }
 
   protected String getConfigItem(String key, String defaultValue) {
-    return initialProperties.getProperty(key, defaultValue);
+    return getConfig().getProperty(key, defaultValue);
   }
 }

--- a/src/test/java/com/adaptris/core/management/jolokia/JettyServerWrapperTest.java
+++ b/src/test/java/com/adaptris/core/management/jolokia/JettyServerWrapperTest.java
@@ -1,0 +1,86 @@
+package com.adaptris.core.management.jolokia;
+
+import com.adaptris.core.management.webserver.JettyServerManager;
+import java.io.IOException;
+import org.eclipse.jetty.server.Server;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class JettyServerWrapperTest {
+
+  @Test
+  public void testDefaultMethods() throws Exception {
+    JettyServerWrapper w = new JettyServerWrapper() {    };
+    w.register();
+    w.start();
+    w.stop();
+    w.destroy();
+  }
+
+  @Test
+  public void testLifecycle() throws Exception {
+    Server server = Mockito.mock(Server.class);
+    Mockito.when(server.isStarted()).thenReturn(true);
+    Mockito.when(server.isStopped()).thenReturn(true);
+    try {
+      JettyServerWrapperImpl wrapper = new JettyServerWrapperImpl(server);
+      wrapper.register();
+      wrapper.start();
+    } finally {
+      stopAndDestroy(server);
+      JettyServerManager.getInstance().removeServer(JettyServerWrapperImpl.SERVER_ID);
+    }
+  }
+
+  @Test
+  public void testLifecycle_StartNotStopped() throws Exception {
+    Server server = Mockito.mock(Server.class);
+    Mockito.when(server.isStopped()).thenReturn(false);
+    try {
+      JettyServerWrapperImpl wrapper = new JettyServerWrapperImpl(server);
+      wrapper.register();
+      wrapper.start();
+    } finally {
+      stopAndDestroy(server);
+      JettyServerManager.getInstance().removeServer(JettyServerWrapperImpl.SERVER_ID);
+    }
+  }
+
+  @Test
+  public void testLifecycle_HasException() throws Exception {
+    Server server = Mockito.mock(Server.class);
+    Mockito.when(server.isStopped()).thenReturn(true);
+    Mockito.doThrow(new RuntimeException()).when(server).start();
+    Mockito.doThrow(new RuntimeException()).when(server).stop();
+    Mockito.doThrow(new RuntimeException()).when(server).destroy();
+    try {
+      JettyServerWrapperImpl wrapper = new JettyServerWrapperImpl(server);
+      wrapper.register();
+      wrapper.start(); // throws an exception which is then eaten quietly
+      wrapper.stop();
+      wrapper.destroy();
+    } finally {
+      JettyServerManager.getInstance().removeServer(JettyServerWrapperImpl.SERVER_ID);
+    }
+  }
+
+  static void stopAndDestroy(Server c) {
+    if (c != null) {
+      executeQuietly(c::stop);
+      executeQuietly(c::destroy);
+    }
+  }
+
+  private static void executeQuietly(Runner r) {
+    try {
+      r.execute();
+    } catch (Exception ignored) {
+
+    }
+  }
+
+  @FunctionalInterface
+  public interface Runner {
+    void execute() throws Exception;
+  }
+}

--- a/src/test/java/com/adaptris/core/management/jolokia/JolokiaComponentTest.java
+++ b/src/test/java/com/adaptris/core/management/jolokia/JolokiaComponentTest.java
@@ -1,19 +1,16 @@
 package com.adaptris.core.management.jolokia;
 
+import com.adaptris.core.management.webserver.JettyServerManager;
+import com.adaptris.interlok.junit.scaffolding.util.PortManager;
 import java.time.Duration;
 import java.util.Properties;
-
 import org.awaitility.Awaitility;
 import org.junit.Test;
 
-import com.adaptris.core.management.webserver.ServerManager;
-import com.adaptris.core.management.webserver.WebServerManagementUtil;
-import com.adaptris.interlok.junit.scaffolding.util.PortManager;
-
 public class JolokiaComponentTest {
 
-  private static final Duration MAX_STARTUP_WAIT = Duration.ofSeconds(5);
-  private static final Duration STARTUP_POLL = Duration.ofMillis(100);
+  static final Duration MAX_STARTUP_WAIT = Duration.ofSeconds(5);
+  static final Duration STARTUP_POLL = Duration.ofMillis(100);
 
   @Test
   public void testFromProperties() throws Exception {
@@ -21,12 +18,11 @@ public class JolokiaComponentTest {
     int portForServer = PortManager.nextUnusedPort(18080);
     try {
       Properties jettyConfig = new Properties();
-      jettyConfig.setProperty(ServerBuilder.JOLOKIA_PORT_CFG_KEY, String.valueOf(portForServer));
+      jettyConfig.setProperty(FromProperties.JOLOKIA_PORT_CFG_KEY, String.valueOf(portForServer));
       jolokia.init(jettyConfig);
-      jolokia.setClassLoader(Thread.currentThread().getContextClassLoader());
       jolokia.start();
       Thread.sleep(250);
-      final ServerManager mgr = WebServerManagementUtil.getServerManager();
+      final JettyServerManager mgr = JettyServerManager.getInstance();
       Awaitility.await().atMost(MAX_STARTUP_WAIT).with().pollInterval(STARTUP_POLL).until(() -> mgr.isStarted());
     } finally {
       stopAndDestroy(jolokia);
@@ -40,14 +36,13 @@ public class JolokiaComponentTest {
     int portForServer = PortManager.nextUnusedPort(18080);
     try {
       Properties jettyConfig = new Properties();
-      jettyConfig.setProperty(ServerBuilder.JOLOKIA_PORT_CFG_KEY, String.valueOf(portForServer));
+      jettyConfig.setProperty(FromProperties.JOLOKIA_PORT_CFG_KEY, String.valueOf(portForServer));
       jettyConfig.setProperty(FromProperties.JOLOKIA_USERNAME_CFG_KEY, "admin");
       jettyConfig.setProperty(FromProperties.JOLOKIA_PASSWORD_CFG_KEY, "admin");
       jolokia.init(jettyConfig);
-      jolokia.setClassLoader(Thread.currentThread().getContextClassLoader());
       jolokia.start();
       Thread.sleep(250);
-      final ServerManager mgr = WebServerManagementUtil.getServerManager();
+      final JettyServerManager mgr = JettyServerManager.getInstance();
       Awaitility.await().atMost(MAX_STARTUP_WAIT).with().pollInterval(STARTUP_POLL).until(() -> mgr.isStarted());
     } finally {
       stopAndDestroy(jolokia);


### PR DESCRIPTION
## Motivation

https://github.com/adaptris/interlok/pull/809 introduced some API changes, which interlok-jolokia can use.

## Modification

- Remove use of WebserverManagementUtil for JSM.getInstance()
- Pushed property constants into the same class for clarity.
- Removed use of system properties since they were only used to pass information to the UI.
- Removed sundry unused properties + defaulted interface methods.


## PR Checklist

- [x] been self-reviewed.
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

What's the end result for the user

## Testing

Compile and follow the instructions from https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-jolokia?id=jolokia-monitoring-and-management-400

```
managementComponents=jmx:jetty:jolokia
```

```
DEBUG [JolokiaEmbeddedJettyStart] [c.a.c.m.j.JolokiaComponent.run()] [{}] Creating Jetty wrapper
TRACE [JolokiaEmbeddedJettyStart] [c.a.c.m.j.JolokiaComponent.build()] [{}] Create Server from Jolokia Properties
DEBUG [JolokiaEmbeddedJettyStart] [c.a.c.m.j.JettyServerWrapperImpl.start()] [{}] JolokiaComponent Started
```

```console
$ curl --location --request POST 'http://localhost:8081/jolokia/' --header 'Content-Type: application/json' --header 'Accept: application/json' \
> --data-raw '{
>   "type" : "READ",
>   "mbean" : "com.adaptris:type=Adapter,id=MyInterlokInstance",
>   "attribute": "ComponentState"
> }'
{"request":{"mbean":"com.adaptris:id=MyInterlokInstance,type=Adapter","attribute":"ComponentState","type":"read"},"value":"StartedState","timestamp":1634719927,"status":200}
```