### PR TITLE
INTERLOK-4081 Upgrade to jetty 10.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ ext {
   log4j2Version = '2.14.1'
   mockitoVersion = '5.2.0'
   jolokiaVersion = '1.7.2'
+  jettyVersion = '10.0.15'
 }
 
 ext.gitBranchNameOrTimestamp = { branchName ->
@@ -117,6 +118,7 @@ configurations.all {
 }
 
 dependencies {
+  api (platform("org.eclipse.jetty:jetty-bom:$jettyVersion"))
   // Since this is all maven now, we should be in a position where SNAPSHOT is auto
   // regarded as CHANGING...
   api ("com.adaptris:interlok-core:$interlokCoreVersion")
@@ -124,8 +126,7 @@ dependencies {
 
   implementation ("org.jolokia:jolokia-core:$jolokiaVersion")
   implementation ("org.jolokia:jolokia-jsr160:$jolokiaVersion")
-  implementation ("org.eclipse.jetty.aggregate:jetty-all:9.4.51.v20230217")
-
+  
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion")
   umlDoclet("nl.talsmasoftware:umldoclet:1.1.4")
 
@@ -202,10 +203,10 @@ javadoc {
 }
 
 jacocoTestReport {
-    reports {
-        xml.required= true
-        html.required= true
-    }
+  reports {
+    xml.required= true
+    html.required= true
+  }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/src/main/java/com/adaptris/core/management/jolokia/FromProperties.java
+++ b/src/main/java/com/adaptris/core/management/jolokia/FromProperties.java
@@ -225,8 +225,9 @@ final class FromProperties extends ServerBuilder {
   }
 
   private ServerConnector createConnector(Server server) {
-    ServerConnector connector = new ServerConnector(server, -1, -1,
-        new HttpConnectionFactory(configure(new HttpConfiguration()), HttpCompliance.RFC2616));
+    HttpConfiguration httpConfig = new HttpConfiguration();
+    httpConfig.setHttpCompliance(HttpCompliance.RFC2616);
+    ServerConnector connector = new ServerConnector(server, -1, -1, new HttpConnectionFactory(configure(httpConfig)));
     connector.setPort(Integer.parseInt(getConfigItem(JOLOKIA_PORT_CFG_KEY, DEFAULT_JOLOKIA_JETTY_PORT)));
     return connector;
   }

--- a/src/main/java/com/adaptris/core/management/jolokia/JolokiaComponent.java
+++ b/src/main/java/com/adaptris/core/management/jolokia/JolokiaComponent.java
@@ -61,20 +61,17 @@ public class JolokiaComponent extends MgmtComponentImpl {
     // This is to make sure we don't break the barrier before the real delay is up.
     //
     final long barrierDelay = STARTUP_WAIT;
-    ManagedThreadFactory.createThread("JolokiaEmbeddedJettyStart", new Runnable() {
-      @Override
-      public void run() {
-        try {
-          log.debug("Creating Jetty wrapper");
-          Thread.currentThread().setContextClassLoader(classLoader);
-          wrapper = new JettyServerWrapperImpl(ServerBuilder.build(properties));
-          wrapper.register();
-          // Wait until at least the server is registered.
-          barrier.await(barrierDelay, TimeUnit.MILLISECONDS);
-          wrapper.start();
-        } catch (final Exception ex) {
-          log.error("Could not create wrapper", ex);
-        }
+    ManagedThreadFactory.createThread("JolokiaEmbeddedJettyStart", (Runnable) () -> {
+      try {
+        log.debug("Creating Jetty wrapper");
+        Thread.currentThread().setContextClassLoader(classLoader);
+        wrapper = new JettyServerWrapperImpl(ServerBuilder.build(properties));
+        wrapper.register();
+        // Wait until at least the server is registered.
+        barrier.await(barrierDelay, TimeUnit.MILLISECONDS);
+        wrapper.start();
+      } catch (final Exception ex) {
+        log.error("Could not create wrapper", ex);
       }
     }).start();
     barrier.await(barrierDelay, TimeUnit.MILLISECONDS);

--- a/src/main/java/com/adaptris/core/management/jolokia/JolokiaLoginService.java
+++ b/src/main/java/com/adaptris/core/management/jolokia/JolokiaLoginService.java
@@ -1,7 +1,11 @@
 package com.adaptris.core.management.jolokia;
 
+import java.util.List;
+
 import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.security.RolePrincipal;
+import org.eclipse.jetty.security.UserPrincipal;
 import org.eclipse.jetty.util.security.Password;
 
 import com.adaptris.security.exc.PasswordException;
@@ -17,11 +21,11 @@ public class JolokiaLoginService extends AbstractLoginService implements LoginSe
   }
 
   @Override
-  protected String[] loadRoleInfo(UserPrincipal user) {
+  protected List<RolePrincipal> loadRoleInfo(UserPrincipal user) {
     if (username.equals(user.getName())) {
-      return new String[] { "jolokia" };
+      return List.of(new RolePrincipal("jolokia"));
     }
-    return null;
+    return List.of();
   }
 
   @Override

--- a/src/test/java/com/adaptris/core/management/jolokia/JolokiaLoginServiceTest.java
+++ b/src/test/java/com/adaptris/core/management/jolokia/JolokiaLoginServiceTest.java
@@ -6,7 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.eclipse.jetty.security.AbstractLoginService.UserPrincipal;
+import java.util.List;
+
+import org.eclipse.jetty.security.RolePrincipal;
+import org.eclipse.jetty.security.UserPrincipal;
 import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.util.security.Credential;
 import org.junit.jupiter.api.Test;
@@ -20,19 +23,19 @@ public class JolokiaLoginServiceTest {
   public void testLoadRoleInfo() throws PasswordException {
     JolokiaLoginService jolokiaLoginService = newJolokiaLoginService();
 
-    String[] roles = jolokiaLoginService.loadRoleInfo(new UserPrincipal("username", null));
+    List<RolePrincipal> roles = jolokiaLoginService.loadRoleInfo(new UserPrincipal("username", null));
 
     assertNotNull(roles);
-    assertEquals("jolokia", roles[0]);
+    assertEquals("jolokia", roles.get(0).getName());
   }
 
   @Test
   public void testLoadRoleInfoInvalidUsername() throws PasswordException {
     JolokiaLoginService jolokiaLoginService = newJolokiaLoginService();
 
-    String[] roles = jolokiaLoginService.loadRoleInfo(new UserPrincipal("invalid", null));
+    List<RolePrincipal> roles = jolokiaLoginService.loadRoleInfo(new UserPrincipal("invalid", null));
 
-    assertNull(roles);
+    assertTrue(roles.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Motivation

We need to upgrade to Jetty 10 to follow core and all the optional components

## Modification

- Basically remove the direct dependency on jetty as we depends on core and common which have jetty as dependencies.
- Update code and tests to work with jetty 10

## PR Checklist

- [x] been self-reviewed.

## Result

No visible change for the end user

## Testing

Create and instance of interlok 5 with interlok-jolokia
Replace interlok-jolokia.jar by the one from this PR.
Add jolokia as management component in bootstrap.properties and start Interlok.

Follow https://github.com/adaptris/interlok-jolokia/blob/develop/README.md

One request is enough to see that it works and not blowing up.

