### PR TITLE
INTERLOK-4477: Upgrade jakarta/Update release version 5.1-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ plugins {
 }
 
 ext {
-  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.0-SNAPSHOT'
-  releaseVersion = project.findProperty('releaseVersion') ?: '5.0-SNAPSHOT'
+  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.1-SNAPSHOT'
+  releaseVersion = project.findProperty('releaseVersion') ?: '5.1-SNAPSHOT'
   nexusBaseUrl = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net/nexus'
   mavenPublishUrl = project.findProperty('mavenPublishUrl') ?: nexusBaseUrl + '/content/repositories/snapshots'
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"
@@ -32,7 +32,7 @@ ext {
   slf4jVersion="2.0.17"
   log4j2Version = "2.14.1"
   mockitoVersion = "5.2.0"
-  jolokiaVersion = "1.7.2"
+  jolokiaVersion = "2.3.0"
   jettyVersion = "10.0.20"
 }
 
@@ -133,8 +133,8 @@ dependencies {
   api ("com.adaptris:interlok-core:$interlokCoreVersion")
   api ("com.adaptris:interlok-common:$interlokCoreVersion")
 
-  implementation ("org.jolokia:jolokia-core:$jolokiaVersion")
-  implementation ("org.jolokia:jolokia-jsr160:$jolokiaVersion")
+  implementation ("org.jolokia:jolokia-server-core:$jolokiaVersion")
+  implementation ("org.jolokia:jolokia-service-jsr160:$jolokiaVersion")
   
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion")
   umlDoclet("nl.talsmasoftware:umldoclet:2.1.0")

--- a/src/main/java/com/adaptris/core/management/jolokia/FromProperties.java
+++ b/src/main/java/com/adaptris/core/management/jolokia/FromProperties.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;
+import org.jolokia.server.core.http.AgentServlet;
 
 /**
  * Build a jetty server from properties.
@@ -119,7 +120,7 @@ final class FromProperties extends ServerBuilder {
   }
 
   private ServletHolder jolokiaServlet() {
-    ServletHolder servletHolder = new ServletHolder("jolokia-agent", org.jolokia.http.AgentServlet.class);
+    ServletHolder servletHolder = new ServletHolder("jolokia-agent", AgentServlet.class);
 
     /*
      * Debugging state after startup. Can be changed via the Config MBean during runtime. Default false


### PR DESCRIPTION
## Motivation

INTERLOK-4477: Upgrade jakarta and jetty, make release version 5.1-SNAPSHOT

## Modification
Updated necessary dependencies and imports to use jakarta instead of javax


## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Compatibility with future versions of jakarta/jetty

## Testing


